### PR TITLE
Add version info

### DIFF
--- a/drucker.proto
+++ b/drucker.proto
@@ -5,6 +5,19 @@ syntax = "proto3";
 
 package drucker;
 
+import "google/protobuf/descriptor.proto";
+extend google.protobuf.FileOptions {
+    string drucker_grpc_proto_version = 50000;
+}
+option (drucker_grpc_proto_version) = "v2";
+
+enum EnumVersionInfo {
+    // Version info. The largest number is the latest version.
+    v0 = 0;
+    v1 = 1;
+    v2 = 2;
+}
+
 // DruckerDashboard: Easy to mange your ML model.
 service DruckerDashboard {
     // Get Service Info.
@@ -100,13 +113,6 @@ service DruckerWorker {
 
     // Input array[string], output array[string].
     rpc Predict_ArrString_ArrString (ArrStringInput) returns (ArrStringOutput) {}
-}
-
-enum EnumVersionInfo {
-    // Version info. The largest number is the latest version.
-    idx_2 = 0;
-    v1 = 1;
-    v2 = 2;
 }
 
 // Request of ServiceInfo.

--- a/drucker.proto
+++ b/drucker.proto
@@ -102,6 +102,13 @@ service DruckerWorker {
     rpc Predict_ArrString_ArrString (ArrStringInput) returns (ArrStringOutput) {}
 }
 
+enum EnumVersionInfo {
+    // Version info. The largest number is the latest version.
+    idx_2 = 0;
+    v1 = 1;
+    v2 = 2;
+}
+
 // Request of ServiceInfo.
 message ServiceInfoRequest {}
 

--- a/run_codegen.py
+++ b/run_codegen.py
@@ -7,4 +7,4 @@ import os
 sd = os.path.abspath(os.path.dirname(__file__))
 os.chdir(sd)
 
-protoc.main(('', '-I.', '--python_out=../', '--grpc_python_out=../', 'drucker.proto',))
+protoc.main(('', '-I/usr/local/include', '-I.', '--python_out=../', '--grpc_python_out=../', 'drucker.proto',))


### PR DESCRIPTION
Add Drucker gRPC version info.

The default value specifies the destination of the latest version by removing the prefix `idx_`. 

### Related issue
https://github.com/drucker/drucker-parent/issues/1