### PR TITLE
Rename repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# drucker-grpc-proto
-Drucker grpc protocol.
+# grpc-proto
+Rekcurd grpc protocol.
 
 ## Parent Project
-https://github.com/drucker/drucker-parent
+https://github.com/rekcurd/community
 
 ## Input/Output
 TODO: Generate automatically from `drucker.proto`

--- a/run_codegen.sh
+++ b/run_codegen.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-echo "[drucker-grpc-proto run_codegen.sh START]"
+echo "[grpc-proto run_codegen.sh START]"
 
 cd `dirname $0`
 


### PR DESCRIPTION
Rename project naming from `drucker` to `rekcurd`.